### PR TITLE
Replacing deprecated methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,13 @@
         "source": "https://github.com/usemuffin/sti"
     },
     "require": {
+        "cakephp/orm": "^3.5"
     },
     "require-dev": {
-        "cakephp/cakephp": "~3.0",
-        "cakephp/cakephp-codesniffer": "2.*",
-        "phpunit/phpunit": "4.1.*"
+        "cakephp/chronos": "^1.1",
+        "cakephp/cakephp": "^3.5",
+        "cakephp/cakephp-codesniffer": "^3.0",
+        "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Model/Behavior/StiBehavior.php
+++ b/src/Model/Behavior/StiBehavior.php
@@ -64,7 +64,7 @@ class StiBehavior extends Behavior
             $args[0] = [];
         }
 
-        $args[0] += [$this->config('typeField') => $type];
+        $args[0] += [$this->getConfig('typeField') => $type];
         return call_user_func_array([$this->_table($type), 'newEntity'], $args);
     }
 

--- a/src/Model/Behavior/StiBehavior.php
+++ b/src/Model/Behavior/StiBehavior.php
@@ -114,7 +114,7 @@ class StiBehavior extends Behavior
             return;
         }
 
-        $class = $event->subject()->entityClass();
+        $class = $event->getSubject()->getEntityClass();
 
         $types = array_combine(
             Hash::extract($this->_typeMap, '{s}.entityClass'),
@@ -149,7 +149,7 @@ class StiBehavior extends Behavior
 
     public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
     {
-        $field = $this->config('typeField');
+        $field = $this->getConfig('typeField');
         if (empty($data[$field])) {
             return;
         }
@@ -158,7 +158,7 @@ class StiBehavior extends Behavior
             throw new \Exception();
         }
 
-        $this->_table()->entityClass($this->_typeMap[$data[$field]]['entityClass']);
+        $this->_table()->getEntityClass($this->_typeMap[$data[$field]]['entityClass']);
     }
 
     public function addType($key, $entityClass)
@@ -174,9 +174,9 @@ class StiBehavior extends Behavior
 
         if (TableRegistry::exists($alias)) {
             $existingTable = TableRegistry::get($alias);
-            if ($table !== $existingTable->table()
-                || $connection !== $existingTable->connection()
-                || $entityClass !== $existingTable->entityClass()
+            if ($table !== $existingTable->getTable()
+                || $connection !== $existingTable->getConnection()
+                || $entityClass !== $existingTable->getEntityClass()
             ) {
                 throw new \Exception();
             }

--- a/tests/TestCase/Model/Behavior/StiBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/StiBehaviorTest.php
@@ -73,7 +73,7 @@ class StiBehaviorTest extends TestCase
 
     public function testFindWithHydrateFalse()
     {
-        $results = $this->Table->find()->contain('Utensils')->hydrate(false)->toArray();
+        $results = $this->Table->find()->contain('Utensils')->disableHydration()->toArray();
         $this->assertTrue(is_array($results[0]));
         $this->assertTrue(is_array($results[0]['utensils'][0]));
     }

--- a/tests/test_app/Model/Table/CooksTable.php
+++ b/tests/test_app/Model/Table/CooksTable.php
@@ -8,7 +8,7 @@ class CooksTable extends Table
 {
     public function initialize(array $config)
     {
-        $this->table('sti_cooks');
+        $this->setTable('sti_cooks');
         $this->addBehavior('Muffin/Sti.Sti', [
             'typeMap' => [
                 'chef' => 'Muffin\Sti\TestApp\Model\Entity\Chef',

--- a/tests/test_app/Model/Table/UtensilsTable.php
+++ b/tests/test_app/Model/Table/UtensilsTable.php
@@ -8,7 +8,7 @@ class UtensilsTable extends Table
 {
     public function initialize(array $config)
     {
-        $this->table('sti_utensils');
+        $this->setTable('sti_utensils');
         $this->addBehavior('Muffin/Sti.Sti', [
             'typeMap' => [
                 'spoon' => 'Muffin\Sti\TestApp\Model\Entity\Spoon',


### PR DESCRIPTION
With CakePHP 3.6, many method names have changed.
For example, `Behaviour::config` was changed to `Behaviour::getConfig` and `Behaviour::setConfig`.
This resulted in a lot of deprecation warnings when using the behaviour with CakePHP 3.6.