### PR TITLE
[3.6] Updating docs to update deprecated example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ class CooksTable extends Table
 {
     public function initialize($config)
     {
-        $this->table('sti_cooks');
+        $this->setTable('sti_cooks');
         $this->addBehavior('Muffin/Sti.Sti', [
             'typeMap' => [
                 'chef' => 'App\Model\Entity\Chef',


### PR DESCRIPTION
`$this->table()` is deprecated so updated it to `$this->setTable()`